### PR TITLE
Fixed java compilation issue

### DIFF
--- a/android/src/main/java/org/zeromq/rnzeromq/ReactNativeZeroMQPackage.java
+++ b/android/src/main/java/org/zeromq/rnzeromq/ReactNativeZeroMQPackage.java
@@ -33,7 +33,7 @@ public class ReactNativeZeroMQPackage implements ReactPackage {
         }
     }
 
-    @Override
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Arrays.asList();
     }


### PR DESCRIPTION
Hi,
I faced the below issue when i try to run the react native application using this library.
 
:react-native-zeromq:compileReleaseJavaWithJavac
D:\wio_mobile\node_modules\react-native-zeromq\android\src\main\java\org\zeromq\rnzeromq\ReactNativeZeroMQPackage.java:36: error: method does not override or implement a method from a supertype
    @Override
    ^
1 error

So, i removed the override overrirde for createJSModules method. Because now it was not there in the ReactPackage interface.
https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java